### PR TITLE
Travis CI: fix old openssl in macos 10.12 and 10.11 (only tlsv1 available)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ jobs:
       # We must use 'rvm: system' because the system ruby doesn't rely on
       # Homebrew, which allows us to reinstall Homebrew without having a
       # damaged ruby. We need ruby because we use the 'aws-sdk-s3' gem.
-      rvm: system
+      # rvm: system
       before_install: # IMPORTANT: HOMEBREW_DEVELOPER must not be set here.
         # First we uninstall any outdated versions of xquartz; otherwise,
         # Homebrew will complain of of older version (2.9.7) being outdated
@@ -107,9 +107,6 @@ jobs:
         - mkdir ~/usr_local && sudo mv /usr/local/* ~/usr_local
         - /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         - travis_retry brew cask reinstall xquartz
-        # This is a bug
-        - ssh -V
-        - brew install openssl
 
     - <<: *run-osx
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,9 @@ jobs:
         - mkdir ~/usr_local && sudo mv /usr/local/* ~/usr_local
         - /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         - travis_retry brew cask reinstall xquartz
+        # This is a bug
+        - ssh -V
+        - brew install openssl
 
     - <<: *run-osx
       os: osx


### PR DESCRIPTION
Try to fix the error:
    # sudo gem install aws-sdk-s3

    ERROR:  Could not find a valid gem 'aws-sdk-s3' (>= 0), here is why:
    Unable to download data from https://rubygems.org/ - SSL_connect returned=1
    errno=0 state=SSLv2/v3 read server hello A: tlsv1 alert protocol version
    (https://rubygems.org/latest_specs.4.8.gz)
    The command "sudo gem install aws-sdk-s3" failed and exited with 2.