### PR TITLE
auto-multiple-choice: rebuild bottles to fix mismatch with cairo lib

### DIFF
--- a/auto-multiple-choice.rb
+++ b/auto-multiple-choice.rb
@@ -4,7 +4,7 @@ class AutoMultipleChoice < Formula
   url "https://bitbucket.org/auto-multiple-choice/auto-multiple-choice/downloads/auto-multiple-choice_1.3.0-2199-bf07b77e8a6d_dist.tar.gz"
   sha256 "582b785e8466a375ec5ddac7b97e11f53b937d493587ff11f52408d6acf77d56"
   version "1.3.0.2199"
-  revision 1
+  revision 2
   # I had to remove the 'head' as we cannot compile using latex in Homebrew.
   # Instead, we use the 'distributed' tarballs from the Bitbucket's Downloads
   # which already contain the doc and doc/sty. See (1) for details.


### PR DESCRIPTION
Error:

    Cairo.c: loadable library and perl binaries are mismatched (got
    handshake key 0xdb00080, needed 0xc500080)

Fixes #14