### PR TITLE
amc: fix for opencv4

### DIFF
--- a/auto-multiple-choice-devel.rb
+++ b/auto-multiple-choice-devel.rb
@@ -427,6 +427,12 @@ class AutoMultipleChoiceDevel < Formula
     # Why? Because @/TEXDIR/@ is using #{prefix} which changes on each version.
     inreplace "AMC-latex-link.pl.in", "@/TEXDIR/@", opt_share/"texmf-local/tex/latex/AMC"
 
+    # These are needed because Homebrew moved to opencv4 on Dec. 28, 2018 and
+    # it broke things. Now c++11 is needed and I use pkg-config for conveniency.
+    inreplace "Makefile", "opencv\)", "opencv4)"
+    inreplace "Makefile", "$(GCC_OPENCV) $(GCC_OPENCV_LIBS)", "$(GCC_OPENCV) $(GCC_OPENCV_LIBS) -std=c++11"
+    inreplace "Makefile-brew.conf", /^GCC_.*/, ""
+
     # Override three variables that cannot be passed as make variables
     # because they are reset in Makefile.conf.
     (buildpath/"Makefile-brew.conf").append_lines <<~EOS

--- a/auto-multiple-choice-devel.rb
+++ b/auto-multiple-choice-devel.rb
@@ -4,7 +4,7 @@ class AutoMultipleChoiceDevel < Formula
   url "https://gitlab.com/jojo_boulix/auto-multiple-choice/uploads/ae5e224c2490bfcdec676a32b1b476f6/auto-multiple-choice_1.4.0_dist.tar.gz"
   version "1.4.0"
   sha256 "d3fba7346043f5dcd392ad24472dcb27f1ee785f1141555a8dbf6d5cd9e78490"
-  revision 0
+  revision 1
   # I had to remove the 'head' as we cannot compile using latex in Homebrew.
   # Instead, we use the 'distributed' tarballs from the Bitbucket's Downloads
   # which already contain the doc and doc/sty. See (1) for details.

--- a/auto-multiple-choice.rb
+++ b/auto-multiple-choice.rb
@@ -4,7 +4,7 @@ class AutoMultipleChoice < Formula
   url "https://gitlab.com/jojo_boulix/auto-multiple-choice/uploads/ae5e224c2490bfcdec676a32b1b476f6/auto-multiple-choice_1.4.0_dist.tar.gz"
   version "1.4.0"
   sha256 "d3fba7346043f5dcd392ad24472dcb27f1ee785f1141555a8dbf6d5cd9e78490"
-  revision 0
+  revision 1
   # I had to remove the 'head' as we cannot compile using latex in Homebrew.
   # Instead, we use the 'distributed' tarballs from the Bitbucket's Downloads
   # which already contain the doc and doc/sty. See (1) for details.

--- a/auto-multiple-choice.rb
+++ b/auto-multiple-choice.rb
@@ -427,6 +427,12 @@ class AutoMultipleChoice < Formula
     # Why? Because @/TEXDIR/@ is using #{prefix} which changes on each version.
     inreplace "AMC-latex-link.pl.in", "@/TEXDIR/@", opt_share/"texmf-local/tex/latex/AMC"
 
+    # These are needed because Homebrew moved to opencv4 on Dec. 28, 2018 and
+    # it broke things. Now c++11 is needed and I use pkg-config for conveniency.
+    inreplace "Makefile", "opencv\)", "opencv4)"
+    inreplace "Makefile", "$(GCC_OPENCV) $(GCC_OPENCV_LIBS)", "$(GCC_OPENCV) $(GCC_OPENCV_LIBS) -std=c++11"
+    inreplace "Makefile-brew.conf", /^GCC_.*/, ""
+
     # Override three variables that cannot be passed as make variables
     # because they are reset in Makefile.conf.
     (buildpath/"Makefile-brew.conf").append_lines <<~EOS


### PR DESCRIPTION
```
> echo "\n" | auto-multiple-choice detect
dyld: Library not loaded: /usr/local/opt/opencv/lib/libopencv_core.3.4.dylib
  Referenced from: /usr/local/Cellar/auto-multiple-choice/1.4.0/lib/AMC/exec/AMC-detect
  Reason: image not found
[1]    48868 done       echo "\n\n\n" |
       48869 abort      auto-multiple-choice detect
```
```
> ls /usr/local/opt/opencv/lib/libopencv_core.*
/usr/local/opt/opencv/lib/libopencv_core.4.0.1.dylib
/usr/local/opt/opencv/lib/libopencv_core.a
/usr/local/opt/opencv/lib/libopencv_core.4.0.dylib
/usr/local/opt/opencv/lib/libopencv_core.dylib
```